### PR TITLE
samples: boards: add reel_board sample

### DIFF
--- a/app/reel_board_ble_broadcast/CMakeLists.txt
+++ b/app/reel_board_ble_broadcast/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(reel_sync)
+
+target_sources(app PRIVATE
+  src/main.c
+  src/led.c
+  src/sensors.c
+  src/display.c
+  src/ble_sync.c
+)

--- a/app/reel_board_ble_broadcast/README.rst
+++ b/app/reel_board_ble_broadcast/README.rst
@@ -1,0 +1,130 @@
+.. zephyr:code-sample:: reel-board-ble-color-sync
+   :name: reel_board BLE color sync + sensor dashboard
+   :relevant-api: bt_gap bluetooth sensor_interface character_framebuffer_interface
+
+   Synchronize an RGB color across reel boards over connectionless BLE and show
+   sensor data on the e-paper display.
+
+Overview
+********
+
+A demo for the PHYTEC **reel board** (nRF52840) that combines connectionless
+Bluetooth Low Energy synchronization with an e-paper sensor dashboard. Every
+board runs the *same* firmware -- there is no master/slave: each board is at
+once a broadcaster and an observer.
+
+- **Press the user button** -- the on-board RGB LED advances to the next color
+  in the palette, and that color is broadcast over BLE so every other board
+  mirrors it.
+- **The e-paper display** shows the latest temperature, humidity, acceleration
+  (X/Y/Z), ambient light, proximity and the currently selected color, refreshed
+  every 2 seconds.
+
+Flash two or more boards, press the button on any one of them, and watch the
+rest converge to the same color.
+
+How it works
+************
+
+Color synchronization (``src/ble_sync.c``)
+==========================================
+
+Synchronization is fully connectionless -- no GATT, no pairing, no connections.
+
+- Each board sends **non-connectable, identity-address advertising**
+  (``BT_LE_ADV_NCONN_IDENTITY``) carrying a small manufacturer-specific payload,
+  while at the same time running a **continuous passive scan**.
+- The 5-byte payload is:
+
+  ===== ============= ==============================================
+  Bytes Field         Notes
+  ===== ============= ==============================================
+  0..1  Company ID    ``0xFFFF``, reserved for testing/local use (LE)
+  2     Magic marker  ``0x52``, so unrelated advertisers are ignored
+  3     Sequence no.  Monotonic, wraps; provides ordering
+  4     Color index   Palette index, mirrored by every board
+  ===== ============= ==============================================
+
+- Ordering is **"latest press wins"**: the sequence number is compared with
+  signed wrap-around arithmetic. When a board sees a *newer* sequence number it
+  adopts the color, **re-broadcasts it** (so late joiners and boards out of
+  radio range still converge), and applies it to the local LED.
+- Scanning runs with **duplicate filtering disabled** -- because every board
+  keeps a stable identity address, the controller would otherwise report a peer
+  only once and later color changes would be missed.
+
+Color palette (``src/led.c``)
+=============================
+
+The RGB LED is driven through the ``led0``/``led1``/``led2`` GPIO aliases
+(active-low, handled by the devicetree flags). The palette cycles through:
+
+``Off -> Red -> Green -> Blue -> Yellow -> Cyan -> Magenta -> White -> Off ...``
+
+Sensors (``src/sensors.c``)
+===========================
+
+Read over I²C through the Zephyr sensor API:
+
+- **HDC1010** -- ambient temperature and humidity
+- **MMA8652FC** -- 3-axis acceleration
+- **APDS9960** -- ambient light and proximity
+
+Missing or unresponsive sensors are reported but do not stop the application;
+the dashboard shows ``---`` for any sensor that is unavailable.
+
+
+Display (``src/display.c``)
+===========================
+
+The SSD16xx e-paper panel (250x122) is driven through the Character Framebuffer
+(CFB) subsystem using the built-in 10x16 font. A full refresh takes roughly a
+second, so it is always rendered from the **system workqueue**, never inline in
+an input or Bluetooth callback.
+
+E-paper SPI to SPIM overlay (``boards/reel_board.overlay``)
+===========================================================
+
+The board default drives the e-paper over the interrupt-per-byte
+``nordic,nrf-spi``. The overlay switches ``spi1`` to the EasyDMA-based
+``nordic,nrf-spim`` so the whole frame transfers with a single completion
+interrupt. This means an e-paper refresh no longer hogs the CPU and can run
+concurrently with BLE advertising/scanning without delaying the controller's
+radio-event prepare -- keeping the radio always on for low-latency color sync.
+
+Building and Running
+********************
+
+Build and flash to a reel board:
+
+.. zephyr-app-commands::
+   :zephyr-app: app/reel_board_ble_broadcast
+   :board: reel_board
+   :goals: build flash
+   :compact:
+
+For revision 2 hardware, use the revision suffix ``reel_board@2``. Repeat for
+each board you want to synchronize.
+
+Sample Output
+=============
+
+On the serial console (output comes from the logging subsystem, so each line is
+prefixed with a timestamp, level and module name):
+
+.. code-block:: console
+
+   [00:00:00.123,000] <inf> app: reel_board BLE color sync + sensor dashboard
+   [00:00:00.456,000] <inf> ble_sync: Bluetooth initialized
+   [00:00:00.457,000] <inf> ble_sync: BLE color sync active (advertising + scanning)
+   [00:00:05.789,000] <inf> ble_sync: TX color=1 seq=1
+   [00:00:07.012,000] <inf> ble_sync: RX color=2 seq=2
+
+- ``TX color=... seq=...`` -- this board broadcast a locally chosen color.
+- ``RX color=... seq=...`` -- this board adopted a newer color from a peer.
+
+Requirements
+************
+
+- Two or more PHYTEC reel boards (a single board still builds, runs, displays
+  sensor data and cycles its own LED -- there is just nothing to sync with).

--- a/app/reel_board_ble_broadcast/boards/reel_board.overlay
+++ b/app/reel_board_ble_broadcast/boards/reel_board.overlay
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Drive the SSD16xx e-paper over the EasyDMA-based "nordic,nrf-spim" instead of
+ * the board-default interrupt-per-byte "nordic,nrf-spi". With DMA the whole
+ * frame is transferred with a single completion interrupt, so a refresh no
+ * longer hogs the CPU and can run concurrently with BLE advertising/scanning
+ * without delaying the controller's radio-event prepare. This keeps the radio
+ * always on (no pause around refresh) for low-latency color sync.
+ *
+ */
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+};

--- a/app/reel_board_ble_broadcast/prj.conf
+++ b/app/reel_board_ble_broadcast/prj.conf
@@ -1,0 +1,33 @@
+# BLE: connectionless broadcaster + observer
+CONFIG_BT=y
+CONFIG_BT_BROADCASTER=y
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_DEVICE_NAME="reel sync"
+CONFIG_BT_RX_STACK_SIZE=4096
+
+# User button via the input subsystem
+CONFIG_GPIO=y
+CONFIG_INPUT=y
+
+# Sensors
+CONFIG_I2C=y
+CONFIG_SENSOR=y
+CONFIG_TI_HDC=y
+CONFIG_FXOS8700=y
+CONFIG_FXOS8700_MODE_ACCEL=y
+CONFIG_APDS9960=y
+CONFIG_APDS9960_ENABLE_ALS=y
+
+# E-paper display through the character framebuffer (CFB) subsystem
+CONFIG_DISPLAY=y
+CONFIG_CHARACTER_FRAMEBUFFER=y
+CONFIG_HEAP_MEM_POOL_SIZE=16384
+
+# Logging subsystem for diagnostics
+CONFIG_LOG=y
+# Floating point formatting for sensor values rendered to the display
+CONFIG_CBPRINTF_FP_SUPPORT=y
+
+# The display is rendered from the system workqueue
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_MAIN_STACK_SIZE=4096

--- a/app/reel_board_ble_broadcast/sample.yaml
+++ b/app/reel_board_ble_broadcast/sample.yaml
@@ -1,0 +1,21 @@
+sample:
+  description: Connectionless BLE color synchronization between reel boards plus an
+    e-paper sensor dashboard
+  name: reel_board BLE color sync
+common:
+  tags:
+    - samples
+    - bluetooth
+    - sensor
+    - display
+  depends_on:
+    - bluetooth
+    - i2c
+    - display
+tests:
+  sample.boards.reel_board.ble_broadcast:
+    platform_allow: reel_board
+    build_only: true
+    tags:
+      - bluetooth
+      - sensor

--- a/app/reel_board_ble_broadcast/src/ble_sync.c
+++ b/app/reel_board_ble_broadcast/src/ble_sync.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+
+#include "ble_sync.h"
+
+LOG_MODULE_REGISTER(ble_sync, LOG_LEVEL_INF);
+
+/* Application marker so we ignore unrelated advertisers. */
+#define SYNC_MAGIC 0x52
+
+/*
+ * Manufacturer-specific advertising payload:
+ *   [0..1] company id (0xFFFF, reserved for testing/local use, little-endian)
+ *   [2]    magic marker
+ *   [3]    sequence number (latest-wins, wraps)
+ *   [4]    color palette index
+ */
+enum {
+	OFF_COMPANY_LO = 0,
+	OFF_COMPANY_HI = 1,
+	OFF_MAGIC = 2,
+	OFF_SEQ = 3,
+	OFF_COLOR = 4,
+	PAYLOAD_LEN = 5,
+};
+
+static uint8_t mfg[PAYLOAD_LEN] = {
+	[OFF_COMPANY_LO] = 0xFF,
+	[OFF_COMPANY_HI] = 0xFF,
+	[OFF_MAGIC] = SYNC_MAGIC,
+	[OFF_SEQ] = 0,
+	[OFF_COLOR] = 0,
+};
+
+static struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg, sizeof(mfg)),
+};
+
+static struct k_mutex lock;
+static uint8_t highest_seq;
+static bool adv_active;
+static ble_color_cb_t remote_color_cb;
+
+/* Re-push the advertising payload from the system workqueue (decouples the
+ * update from the caller's context, e.g. the BT RX thread).
+ */
+static void adv_update_work_fn(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (!adv_active) {
+		return;
+	}
+
+	int err = bt_le_adv_update_data(ad, ARRAY_SIZE(ad), NULL, 0);
+
+	if (err) {
+		LOG_ERR("adv update failed (err %d)", err);
+	}
+}
+static K_WORK_DEFINE(adv_update_work, adv_update_work_fn);
+
+/* Store seq/color into the advertised payload. */
+static void set_payload(uint8_t seq, uint8_t color)
+{
+	highest_seq = seq;
+	mfg[OFF_SEQ] = seq;
+	mfg[OFF_COLOR] = color;
+
+	k_work_submit(&adv_update_work);
+}
+
+void ble_sync_broadcast(uint8_t color_idx)
+{
+	uint8_t next;
+
+	k_mutex_lock(&lock, K_FOREVER);
+	next = highest_seq + 1U;
+
+	set_payload(next, color_idx);
+	k_mutex_unlock(&lock);
+	LOG_INF("TX color=%u seq=%u", color_idx, next);
+}
+
+/* --- scanning --- */
+
+struct parse_ctx {
+	bool found;
+	uint8_t seq;
+	uint8_t color;
+};
+
+static bool parse_cb(struct bt_data *data, void *user_data)
+{
+	struct parse_ctx *ctx = user_data;
+
+	if (data->type != BT_DATA_MANUFACTURER_DATA ||
+	    data->data_len < PAYLOAD_LEN) {
+		return true; /* keep parsing */
+	}
+
+	if (data->data[OFF_COMPANY_LO] != 0xFF ||
+	    data->data[OFF_COMPANY_HI] != 0xFF ||
+	    data->data[OFF_MAGIC] != SYNC_MAGIC) {
+		return true;
+	}
+
+	ctx->found = true;
+	ctx->seq = data->data[OFF_SEQ];
+	ctx->color = data->data[OFF_COLOR];
+	return false; /* stop parsing */
+}
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *buf)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(rssi);
+	ARG_UNUSED(type);
+
+	struct parse_ctx ctx = {0};
+
+	bt_data_parse(buf, parse_cb, &ctx);
+	if (!ctx.found) {
+		return;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+	bool newer = (int8_t)(ctx.seq - highest_seq) > 0;
+	k_mutex_unlock(&lock);
+
+	if (!newer) {
+		return;
+	}
+
+	LOG_INF("RX color=%u seq=%u", ctx.color, ctx.seq);
+
+	/* Adopt: rebroadcast so late joiners converge, then apply locally. */
+	set_payload(ctx.seq, ctx.color);
+
+	if (remote_color_cb) {
+		remote_color_cb(ctx.color);
+	}
+}
+
+/* Continuous passive scan with NO duplicate filtering: every board keeps a
+ * stable identity address, so the controller would otherwise report a peer only
+ * once and we'd miss later color changes. We need every advertising event.
+ */
+static const struct bt_le_scan_param scan_param = {
+	.type = BT_LE_SCAN_TYPE_PASSIVE,
+	.options = BT_LE_SCAN_OPT_NONE,
+	.interval = BT_GAP_SCAN_FAST_INTERVAL_MIN, /* window == interval */
+	.window = BT_GAP_SCAN_FAST_WINDOW,
+};
+
+/* Start advertising (current color payload) + scanning. */
+static int start_radio(void)
+{
+	int err;
+
+	err = bt_le_adv_start(BT_LE_ADV_NCONN_IDENTITY, ad, ARRAY_SIZE(ad),
+			      NULL, 0);
+	if (err) {
+		LOG_ERR("Advertising start failed (err %d)", err);
+		return err;
+	}
+	adv_active = true;
+
+	err = bt_le_scan_start(&scan_param, device_found);
+	if (err) {
+		LOG_ERR("Scan start failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int ble_sync_init(ble_color_cb_t on_remote_color)
+{
+	int err;
+
+	remote_color_cb = on_remote_color;
+	k_mutex_init(&lock);
+
+	err = bt_enable(NULL);
+	if (err) {
+		LOG_ERR("Bluetooth init failed (err %d)", err);
+		return err;
+	}
+	LOG_INF("Bluetooth initialized");
+
+	err = start_radio();
+	if (err) {
+		return err;
+	}
+
+	LOG_INF("BLE color sync active (advertising + scanning)");
+	return 0;
+}

--- a/app/reel_board_ble_broadcast/src/ble_sync.h
+++ b/app/reel_board_ble_broadcast/src/ble_sync.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Connectionless BLE color synchronization. Each board advertises its current
+ * color (manufacturer data) while scanning for other boards. A monotonic
+ * sequence number provides "latest press wins" ordering across all boards.
+ */
+
+#ifndef REEL_SYNC_BLE_SYNC_H_
+#define REEL_SYNC_BLE_SYNC_H_
+
+#include <stdint.h>
+
+/* Invoked (from the BT RX context) when a newer color is received from a peer. */
+typedef void (*ble_color_cb_t)(uint8_t color_idx);
+
+/*
+ * Enable Bluetooth, start non-connectable advertising and passive scanning.
+ * @p on_remote_color is called whenever a peer's newer color is adopted.
+ */
+int ble_sync_init(ble_color_cb_t on_remote_color);
+
+/*
+ * Announce a locally chosen color (user pressed the button): take the next
+ * sequence number and update the advertised payload so peers adopt it.
+ */
+void ble_sync_broadcast(uint8_t color_idx);
+
+#endif /* REEL_SYNC_BLE_SYNC_H_ */

--- a/app/reel_board_ble_broadcast/src/display.c
+++ b/app/reel_board_ble_broadcast/src/display.c
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/display/cfb.h>
+#include <zephyr/logging/log.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "display.h"
+
+LOG_MODULE_REGISTER(display, LOG_LEVEL_INF);
+
+static const struct device *const epd = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+
+/*
+ * Default CFB font index 0 is the 10x16 "font1016". On the 250x122 panel that
+ * gives 25 columns and 7 rows, which comfortably fits the dashboard below.
+ */
+#define FONT_IDX        0
+#define ROW_HEIGHT_PX   16
+
+static void print_row(int row, const char *text)
+{
+	if (cfb_print(epd, text, 0, row * ROW_HEIGHT_PX)) {
+		LOG_ERR("cfb_print row %d failed", row);
+	}
+}
+
+/* Print text horizontally centered on a row. */
+static void print_centered(int row, const char *text)
+{
+	uint8_t fw, fh;
+	int x = 0;
+
+	if (cfb_get_font_size(epd, FONT_IDX, &fw, &fh) == 0 && fw > 0) {
+		int cols = cfb_get_display_parameter(epd, CFB_DISPLAY_WIDTH) / fw;
+		int len = strlen(text);
+
+		if (cols > len) {
+			x = ((cols - len) / 2) * fw;
+		}
+	}
+
+	if (cfb_print(epd, text, x, row * ROW_HEIGHT_PX)) {
+		LOG_ERR("cfb_print row %d failed", row);
+	}
+}
+
+int display_init(void)
+{
+	if (!device_is_ready(epd)) {
+		LOG_ERR("Display %s not ready", epd->name);
+		return -ENODEV;
+	}
+
+	if (cfb_framebuffer_init(epd)) {
+		LOG_ERR("Framebuffer init failed");
+		return -EIO;
+	}
+
+	cfb_framebuffer_set_font(epd, FONT_IDX);
+	cfb_framebuffer_clear(epd, true);
+	cfb_framebuffer_invert(epd);
+
+	return 0;
+}
+
+void display_show(const struct app_sensors *s, const char *color_name)
+{
+	char line[26];
+
+	cfb_framebuffer_clear(epd, false);
+	cfb_framebuffer_set_font(epd, FONT_IDX);
+
+	print_centered(0, "reel_board sync");
+
+	if (s->hdc_ok) {
+		snprintf(line, sizeof(line), "T:%.1fC H:%.0f%%",
+			 s->temp_c, s->humidity);
+	} else {
+		snprintf(line, sizeof(line), "T/H: ---");
+	}
+	print_row(1, line);
+
+	if (s->accel_ok) {
+		snprintf(line, sizeof(line), "A:%.1f %.1f %.1f",
+			 s->accel_x, s->accel_y, s->accel_z);
+	} else {
+		snprintf(line, sizeof(line), "Accel: ---");
+	}
+	print_row(2, line);
+
+	if (s->apds_ok) {
+		snprintf(line, sizeof(line), "Light:%.0f", s->light);
+		print_row(3, line);
+		snprintf(line, sizeof(line), "Prox:%.0f", s->prox);
+		print_row(4, line);
+	} else {
+		print_row(3, "Light/Prox: ---");
+		print_row(4, "");
+	}
+
+	snprintf(line, sizeof(line), "Color: %s", color_name);
+	print_row(5, line);
+
+	int err = cfb_framebuffer_finalize(epd);
+
+	if (err) {
+		LOG_ERR("cfb_framebuffer_finalize failed (%d)", err);
+	}
+}

--- a/app/reel_board_ble_broadcast/src/display.h
+++ b/app/reel_board_ble_broadcast/src/display.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Sensor dashboard rendered on the reel_board e-paper display via CFB.
+ */
+
+#ifndef REEL_SYNC_DISPLAY_H_
+#define REEL_SYNC_DISPLAY_H_
+
+#include "sensors.h"
+
+/* Initialize the e-paper display and character framebuffer. */
+int display_init(void);
+
+/* Render the sensor readings and the active LED color onto the panel. */
+void display_show(const struct app_sensors *s, const char *color_name);
+
+#endif /* REEL_SYNC_DISPLAY_H_ */

--- a/app/reel_board_ble_broadcast/src/led.c
+++ b/app/reel_board_ble_broadcast/src/led.c
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
+
+#include "led.h"
+
+LOG_MODULE_REGISTER(led, LOG_LEVEL_INF);
+
+/*
+ * reel_board RGB LED. The three channels are exposed as aliases led0 (red),
+ * led1 (green) and led2 (blue) and are wired active-low; the GPIO_DT_SPEC
+ * flags handle the inversion so gpio_pin_set_dt(..., 1) means "on".
+ */
+static const struct gpio_dt_spec rgb[] = {
+	GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios), /* red   */
+	GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios), /* green */
+	GPIO_DT_SPEC_GET(DT_ALIAS(led2), gpios), /* blue  */
+};
+
+/* Palette: {R, G, B} on/off per channel. Index 0 is "all off". */
+static const struct {
+	uint8_t r, g, b;
+	const char *name;
+} palette[LED_COLOR_COUNT] = {
+	{0, 0, 0, "Off"},
+	{1, 0, 0, "Red"},
+	{0, 1, 0, "Green"},
+	{0, 0, 1, "Blue"},
+	{1, 1, 0, "Yellow"},
+	{0, 1, 1, "Cyan"},
+	{1, 0, 1, "Magenta"},
+	{1, 1, 1, "White"},
+};
+
+static uint8_t current_idx;
+
+int led_init(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(rgb); i++) {
+		if (!gpio_is_ready_dt(&rgb[i])) {
+			LOG_ERR("LED channel %u not ready", (unsigned int)i);
+			return -ENODEV;
+		}
+
+		int err = gpio_pin_configure_dt(&rgb[i], GPIO_OUTPUT_INACTIVE);
+
+		if (err) {
+			LOG_ERR("LED channel %u config failed (%d)",
+				(unsigned int)i, err);
+			return err;
+		}
+	}
+
+	led_set(0);
+	return 0;
+}
+
+void led_set(uint8_t idx)
+{
+	idx %= LED_COLOR_COUNT;
+	current_idx = idx;
+
+	gpio_pin_set_dt(&rgb[0], palette[idx].r);
+	gpio_pin_set_dt(&rgb[1], palette[idx].g);
+	gpio_pin_set_dt(&rgb[2], palette[idx].b);
+}
+
+uint8_t led_get(void)
+{
+	return current_idx;
+}
+
+uint8_t led_next_index(void)
+{
+	return (current_idx + 1) % LED_COLOR_COUNT;
+}
+
+const char *led_color_name(uint8_t idx)
+{
+	return palette[idx % LED_COLOR_COUNT].name;
+}

--- a/app/reel_board_ble_broadcast/src/led.h
+++ b/app/reel_board_ble_broadcast/src/led.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * RGB LED palette driven over the reel_board's GPIO LEDs (led0/led1/led2).
+ */
+
+#ifndef REEL_SYNC_LED_H_
+#define REEL_SYNC_LED_H_
+
+#include <stdint.h>
+
+/* Number of entries in the color palette (index 0 == off). */
+#define LED_COLOR_COUNT 8
+
+/* Initialize the RGB GPIO LEDs. Returns 0 on success. */
+int led_init(void);
+
+/* Drive the RGB LED to palette entry @p idx (wrapped into range). */
+void led_set(uint8_t idx);
+
+/* Currently displayed palette index. */
+uint8_t led_get(void);
+
+/* Next palette index after the current one (wraps around). */
+uint8_t led_next_index(void);
+
+/* Human readable name for a palette index, e.g. "Green". */
+const char *led_color_name(uint8_t idx);
+
+#endif /* REEL_SYNC_LED_H_ */

--- a/app/reel_board_ble_broadcast/src/main.c
+++ b/app/reel_board_ble_broadcast/src/main.c
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * reel_board demo: BLE color synchronization between identical boards plus an
+ * e-paper sensor dashboard.
+ *
+ *  - Press the user button: the local RGB LED advances to the next color and
+ *    that color is broadcast so every other board mirrors it. Each board is
+ *    both sender and receiver (identical firmware, no master).
+ *  - The e-paper display shows temperature, humidity, acceleration (X/Y/Z),
+ *    ambient light and proximity, refreshed every 2 seconds.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/input/input.h>
+#include <zephyr/logging/log.h>
+
+#include "led.h"
+#include "sensors.h"
+#include "display.h"
+#include "ble_sync.h"
+
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
+
+#define DISPLAY_REFRESH_INTERVAL K_SECONDS(2)
+
+static void display_work_fn(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(display_work, display_work_fn);
+
+/* Re-render the e-paper panel (runs on the system workqueue, never inline in
+ * an input/BT callback because a full e-paper refresh takes ~1 s).
+ */
+static void display_work_fn(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	struct app_sensors s;
+
+	sensors_read(&s);
+	display_show(&s, led_color_name(led_get()));
+
+	k_work_reschedule(&display_work, DISPLAY_REFRESH_INTERVAL);
+}
+
+static void request_display_refresh(void)
+{
+	k_work_reschedule(&display_work, K_NO_WAIT);
+}
+
+/* A peer announced a new color over BLE: mirror it locally. */
+static void on_remote_color(uint8_t color_idx)
+{
+	led_set(color_idx);
+	request_display_refresh();
+}
+
+/* User button: advance the local color and broadcast it to the other boards. */
+static void input_cb(struct input_event *evt, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	if (evt->type != INPUT_EV_KEY || evt->code != INPUT_KEY_0 ||
+	    evt->value == 0) {
+		return;
+	}
+
+	uint8_t idx = led_next_index();
+
+	led_set(idx);
+	ble_sync_broadcast(idx);
+	request_display_refresh();
+}
+INPUT_CALLBACK_DEFINE(NULL, input_cb, NULL);
+
+int main(void)
+{
+	LOG_INF("reel_board BLE color sync + sensor dashboard");
+
+	if (led_init()) {
+		LOG_ERR("LED init failed");
+	}
+
+	if (display_init()) {
+		LOG_ERR("Display init failed");
+	}
+
+	if (sensors_init()) {
+		LOG_WRN("One or more sensors unavailable (continuing)");
+	}
+
+	if (ble_sync_init(on_remote_color)) {
+		LOG_ERR("BLE sync init failed");
+	}
+
+	/* Draw the first frame immediately; the work item re-arms itself. */
+	request_display_refresh();
+
+	return 0;
+}

--- a/app/reel_board_ble_broadcast/src/sensors.c
+++ b/app/reel_board_ble_broadcast/src/sensors.c
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+
+#include "sensors.h"
+
+LOG_MODULE_REGISTER(sensors, LOG_LEVEL_INF);
+
+/* Device handles, resolved from the board devicetree compatibles. */
+static const struct device *const hdc1010 = DEVICE_DT_GET_ONE(ti_hdc1010);
+static const struct device *const mma8652 = DEVICE_DT_GET_ONE(nxp_mma8652fc);
+static const struct device *const apds9960 = DEVICE_DT_GET_ONE(avago_apds9960);
+
+int sensors_init(void)
+{
+	int ret = 0;
+
+	if (!device_is_ready(hdc1010)) {
+		LOG_WRN("HDC1010 (temp/humidity) not ready");
+		ret = -ENODEV;
+	}
+	if (!device_is_ready(mma8652)) {
+		LOG_WRN("MMA8652FC (accel) not ready");
+		ret = -ENODEV;
+	}
+	if (!device_is_ready(apds9960)) {
+		LOG_WRN("APDS9960 (light/prox) not ready");
+		ret = -ENODEV;
+	}
+
+	return ret;
+}
+
+static bool read_hdc1010(struct app_sensors *out)
+{
+	struct sensor_value temp, humidity;
+
+	if (sensor_sample_fetch(hdc1010) ||
+	    sensor_channel_get(hdc1010, SENSOR_CHAN_AMBIENT_TEMP, &temp) ||
+	    sensor_channel_get(hdc1010, SENSOR_CHAN_HUMIDITY, &humidity)) {
+		return false;
+	}
+
+	out->temp_c = sensor_value_to_double(&temp);
+	out->humidity = sensor_value_to_double(&humidity);
+	return true;
+}
+
+static bool read_mma8652(struct app_sensors *out)
+{
+	struct sensor_value accel[3];
+
+	if (sensor_sample_fetch(mma8652) ||
+	    sensor_channel_get(mma8652, SENSOR_CHAN_ACCEL_XYZ, accel)) {
+		return false;
+	}
+
+	out->accel_x = sensor_value_to_double(&accel[0]);
+	out->accel_y = sensor_value_to_double(&accel[1]);
+	out->accel_z = sensor_value_to_double(&accel[2]);
+	return true;
+}
+
+static bool read_apds9960(struct app_sensors *out)
+{
+	struct sensor_value light, prox;
+
+	if (sensor_sample_fetch(apds9960) ||
+	    sensor_channel_get(apds9960, SENSOR_CHAN_LIGHT, &light) ||
+	    sensor_channel_get(apds9960, SENSOR_CHAN_PROX, &prox)) {
+		return false;
+	}
+
+	out->light = sensor_value_to_double(&light);
+	out->prox = sensor_value_to_double(&prox);
+	return true;
+}
+
+void sensors_read(struct app_sensors *out)
+{
+	memset(out, 0, sizeof(*out));
+
+	out->hdc_ok = read_hdc1010(out);
+	out->accel_ok = read_mma8652(out);
+	out->apds_ok = read_apds9960(out);
+}

--- a/app/reel_board_ble_broadcast/src/sensors.h
+++ b/app/reel_board_ble_broadcast/src/sensors.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Reads the reel_board on-board sensors (HDC1010, MMA8652FC, APDS9960).
+ */
+
+#ifndef REEL_SYNC_SENSORS_H_
+#define REEL_SYNC_SENSORS_H_
+
+#include <stdbool.h>
+
+struct app_sensors {
+	double temp_c;     /* HDC1010 ambient temperature  [degC]   */
+	double humidity;   /* HDC1010 relative humidity     [%RH]   */
+	double accel_x;    /* MMA8652FC acceleration X       [m/s^2] */
+	double accel_y;    /* MMA8652FC acceleration Y       [m/s^2] */
+	double accel_z;    /* MMA8652FC acceleration Z       [m/s^2] */
+	double light;      /* APDS9960 ambient light         [a.u.] */
+	double prox;       /* APDS9960 proximity             [a.u.] */
+
+	bool hdc_ok;
+	bool accel_ok;
+	bool apds_ok;
+};
+
+/* Check that all sensor devices are ready. Returns 0 if all present. */
+int sensors_init(void);
+
+/* Sample every sensor into @p out. Per-sensor *_ok flags report success. */
+void sensors_read(struct app_sensors *out);
+
+#endif /* REEL_SYNC_SENSORS_H_ */


### PR DESCRIPTION
This adds a sample project for the reel_board,
that displays all sensor values on the display and implements a BLE broadcast synchronisation for
the LED.